### PR TITLE
[✨Feat(#8)] Mock 엔드포인트 구현

### DIFF
--- a/app/router/weather.py
+++ b/app/router/weather.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+from app.schema.weather import WeatherBriefingRequest, WeatherBriefingResponse
+from app.service.weather import get_weather_briefing
+
+router = APIRouter(prefix="/api/v1/weather", tags=["weather"])
+
+
+@router.post("/briefing", response_model=WeatherBriefingResponse)
+async def weather_briefing(request: WeatherBriefingRequest) -> WeatherBriefingResponse:
+    return await get_weather_briefing(request)

--- a/app/service/weather.py
+++ b/app/service/weather.py
@@ -1,0 +1,14 @@
+from app.schema.weather import WeatherBriefingRequest, WeatherBriefingResponse, IconCode, Clothing
+
+
+async def get_weather_briefing(request: WeatherBriefingRequest) -> WeatherBriefingResponse:
+    """
+    날씨 브리핑을 생성
+    현재는 Mock 고정값을 반환
+    TODO: Gemini 연동 시 이 함수 내부를 교체하기
+    """
+    return WeatherBriefingResponse(
+        message="오늘은 구름이 제법 많이 끼어 있네요. 나서실 때는 얇은 외투 하나 챙기시는 게 좋을 것 같아요. 체감 온도가 실제보다 조금 낮아요.",
+        icon_code=IconCode.CLOUDY,
+        clothing=[Clothing.LONG_SLEEVE, Clothing.LIGHT_JACKET],
+    )

--- a/main.py
+++ b/main.py
@@ -1,4 +1,9 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
+from app.router.weather import router as weather_router
+from app.schema.error import ErrorCode, ErrorResponse
 
 app = FastAPI(
     title="Dayleaf AI",
@@ -6,6 +11,30 @@ app = FastAPI(
     version="0.1.0",
 )
 
+# 라우터 등록
+app.include_router(weather_router)
+
+# 422 에러 핸들러
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request: Request, exc: RequestValidationError):
+    return JSONResponse(
+        status_code=422,
+        content=ErrorResponse(
+            error_code=ErrorCode.INVALID_REQUEST,
+            message="요청 형식이 올바르지 않습니다.",
+        ).model_dump(),
+    )
+
+# 500 에러 핸들러
+@app.exception_handler(Exception)
+async def internal_exception_handler(request: Request, exc: Exception):
+    return JSONResponse(
+        status_code=500,
+        content=ErrorResponse(
+            error_code=ErrorCode.INTERNAL_SERVER_ERROR,
+            message="예상치 못한 서버 오류가 발생했습니다.",
+        ).model_dump(),
+    )
 
 @app.get("/health")
 async def health_check():


### PR DESCRIPTION
## 📣 Related Issue

- #8 

## 📝 Summary

- `app/router/weather.py` 구현 — `POST /api/v1/weather/briefing` Mock 엔드포인트 추가
- `app/service/weather.py` 뼈대 생성 — Gemini 연동 시 내부만 교체할 수 있도록 함수 시그니처 정의
- `main.py` 라우터 및 에러 핸들러 등록 — `422 INVALID_REQUEST`, `500 INTERNAL_SERVER_ERROR`

## 🙏PR point

- 현재 `POST /api/v1/weather/briefing`은 Gemini를 호출하지 않고 `api-contract.md`에 정의된 고정값을 반환합니다. Spring Boot 팀은 이 엔드포인트로 프론트엔드 연동 개발을 병렬로 진행할 수 있습니다.
- 이후 Gemini 연동 시 `app/service/weather.py` 내부만 교체하면 되도록 구조를 잡아두었습니다.

## 📬 Reference

- `docs/api-contract.md`