### PR TITLE
[Feat/#14] Gemini 응답 파싱 레이어 분리 및 GEMINI_PARSE_ERROR 테스트 추가

### DIFF
--- a/app/parser/weather.py
+++ b/app/parser/weather.py
@@ -1,0 +1,50 @@
+# Gemini가 반환한 raw JSON 문자열을 WeatherBriefingResponse Pydantic 모델로 변환한다.
+
+# 발생 가능한 예외 (모두 호출자로 전파):
+# - json.JSONDecodeError : Gemini가 JSON이 아닌 형식으로 응답한 경우
+# - KeyError             : JSON에 필수 키(message, icon_code, clothing)가 없는 경우
+# - ValueError           : Enum 변환 실패 — 정의되지 않은 icon_code/clothing 값인 경우
+
+import json
+
+from app.schema.weather import Clothing, IconCode, WeatherBriefingResponse
+
+# JSON 필수 키 상수 정의
+# 하드코딩된 문자열 리터럴 대신 상수로 관리한다.
+# 이유:
+#   - 오타로 인한 런타임 KeyError를 방지한다.
+#   - 키 이름이 변경될 때 이 상수만 수정하면 된다.
+_KEY_MESSAGE = "message"
+_KEY_ICON_CODE = "icon_code"
+_KEY_CLOTHING = "clothing"
+
+
+def parse_briefing_response(raw_text: str) -> WeatherBriefingResponse:
+    """
+    Gemini가 반환한 raw JSON 문자열을 WeatherBriefingResponse로 변환한다.
+
+    변환 흐름:
+      1) raw_text(JSON 문자열) → Python dict (json.loads)
+      2) dict의 각 값 → Pydantic Enum 타입으로 변환
+      3) WeatherBriefingResponse 모델 생성 후 반환
+    """
+
+    # 1. JSON 문자열 → Python dict
+    # json.loads()는 파싱 실패 시 json.JSONDecodeError를 발생시킨다.
+    # 이 예외는 잡지 않고 호출자(service)로 전파한다.
+    data: dict = json.loads(raw_text)
+
+    # 2, 3. dict → Pydantic 모델 변환
+    return WeatherBriefingResponse(
+        # dict에서 값을 꺼낸다.
+        # 해당 키가 없으면 KeyError가 발생하며, 호출자(service)로 전파된다.
+        message=data[_KEY_MESSAGE],
+
+        # 문자열 "CLOUDY" → IconCode.CLOUDY Enum으로 변환한다.
+        # 정의되지 않은 값이면 ValueError가 발생하며, 호출자(service)로 전파된다.
+        icon_code=IconCode(data[_KEY_ICON_CODE]),
+
+        # 문자열 리스트 ["LONG_SLEEVE", "JACKET"] → Clothing Enum 리스트로 변환한다.
+        # 리스트 내 하나라도 정의되지 않은 값이면 ValueError가 발생하며, 호출자(service)로 전파된다.
+        clothing=[Clothing(item) for item in data[_KEY_CLOTHING]],
+    )

--- a/app/service/weather.py
+++ b/app/service/weather.py
@@ -1,9 +1,11 @@
-# Gemini 1.5 Flash를 호출하여 사서 톤의 날씨 브리핑을 생성한다.
 # 라우터 (router/weather.py)와 Gemini 클라이언트 (core/gemini.py) 사이의 비즈니스 로직 레이어이다.
 
 # 흐름 : [라우터] → get_weather_briefing() → [프롬프트 빌드] → [Gemini 호출] → [응답 파싱] → [라우터]
 
-import json
+# 레이어별 책임 분리:
+# - prompt/weather.py : 프롬프트 문자열 조립
+# - service/weather.py: Gemini 호출 + 예외의 HTTP 변환 책임
+# - parser/weather.py : raw JSON 문자열 → Pydantic 모델 변환 (순수 변환, HTTP 무관)
 
 import google.generativeai as genai
 from fastapi import HTTPException
@@ -13,37 +15,56 @@ from google.api_core.exceptions import DeadlineExceeded, GoogleAPICallError
 # 즉, 이 줄 하나로 Gemini API 키 인증이 완료된다.
 import app.core.gemini
 
+from app.parser.weather import parse_briefing_response
 from app.prompt.weather import SYSTEM_PROMPT, build_user_prompt
 from app.schema.error import ErrorCode
-from app.schema.weather import (
-    Clothing,
-    IconCode,
-    WeatherBriefingRequest,
-    WeatherBriefingResponse,
-)
+from app.schema.weather import WeatherBriefingRequest, WeatherBriefingResponse
+
+# Gemini 모델 이름 상수
+# 하드코딩된 문자열 대신 상수로 관리한다.
+# 이유:
+#   - 모델 이름 변경 시 이 상수만 수정하면 된다.
+#   - 오타로 인한 런타임 오류를 방지한다.
+_GEMINI_MODEL_NAME = "models/gemini-2.5-flash"
+
+# Gemini GenerationConfig 상수
+# 각 값의 의미와 선택 이유를 상수명과 주석으로 명시한다.
+
+# temperature: 모델의 창의성 수준 (0.0 ~ 1.0)
+# 0.7 = 분류 정확성(icon_code, clothing)과 문체 다양성(message)의 균형점
+_TEMPERATURE = 0.7
+
+# max_output_tokens: 브리핑 메시지(2문장) + JSON 구조 오버헤드를 고려한 적정 토큰 수
+_MAX_OUTPUT_TOKENS = 2048
+
+# 인증 에러 판별 키워드 목록
+# GoogleAPICallError 메시지 문자열로 인증 오류와 일반 API 오류를 구분한다.
+# 하드코딩 방지를 위해 상수로 분리하며, 새로운 키워드 추가 시 이 목록만 수정한다.
+_AUTH_ERROR_KEYWORDS = ("API_KEY", "PERMISSION_DENIED", "UNAUTHENTICATED")
+
 
 async def get_weather_briefing(request: WeatherBriefingRequest) -> WeatherBriefingResponse:
     """
-    날씨 브리핑 생성의 진입점(entry point)
+    날씨 브리핑 생성의 진입점(entry point).
 
     이 함수는 라우터에서 직접 호출되며, 크게 세 단계로 동작한다:
       1단계) 유저 프롬프트 빌드: cold_sensitivity와 날씨 데이터를 자연어로 조합
       2단계) Gemini API 호출: 시스템 프롬프트 + 유저 프롬프트로 JSON 브리핑 생성
-      3단계) 응답 파싱: JSON 문자열을 WeatherBriefingResponse Pydantic 모델로 변환
+      3단계) 응답 파싱: raw JSON 문자열을 parser 레이어에 위임 후 HTTPException으로 변환
     """
 
-    # ── 1단계: 유저 프롬프트 빌드 ────────────────────────────────────────────────
-    # build_user_prompt()는 app/prompt/weather.py에서 정의된 함수
+    # 1. 유저 프롬프트 빌드
+    # build_user_prompt()는 app/prompt/weather.py에서 정의된 함수.
     # cold_sensitivity Enum을 자연어로 변환하고,
     # 날씨 데이터를 마크다운 형식으로 조립해 Gemini가 읽기 쉬운 텍스트를 만든다.
     user_prompt = build_user_prompt(request)
 
-    # ── 2단계: Gemini API 호출 ────────────────────────────────────────────────────
+    # 2. Gemini API 호출
     try:
         # system_instruction은 generate_content_async()가 아닌
         # GenerativeModel() 생성자에 전달해야 한다.
         model = genai.GenerativeModel(
-            model_name="models/gemini-2.5-flash",  # 먼저 이걸로 시도
+            model_name=_GEMINI_MODEL_NAME,
             system_instruction=SYSTEM_PROMPT,  # 사서 '리프'의 페르소나 및 응답 규칙
         )
 
@@ -54,13 +75,8 @@ async def get_weather_briefing(request: WeatherBriefingRequest) -> WeatherBriefi
             generation_config=genai.GenerationConfig(
                 # JSON만 반환하도록 모델 레벨에서 강제한다.
                 response_mime_type="application/json",
-
-                # temperature: 모델의 창의성 수준 (0.0 ~ 1.0)
-                # 0.7 = 분류 정확성(icon_code, clothing)과 문체 다양성(message)의 균형점
-                temperature=0.7,
-
-                # 브리핑 메시지(2~3문장) + JSON 구조 오버헤드를 고려한 적정 토큰 수
-                max_output_tokens=2048,
+                temperature=_TEMPERATURE,
+                max_output_tokens=_MAX_OUTPUT_TOKENS,
             ),
         )
 
@@ -75,12 +91,9 @@ async def get_weather_briefing(request: WeatherBriefingRequest) -> WeatherBriefi
         )
 
     except GoogleAPICallError as e:
-        # GoogleAPICallError는 Gemini SDK의 모든 API 오류의 상위 예외
+        # GoogleAPICallError는 Gemini SDK의 모든 API 오류의 상위 예외.
         # 에러 메시지 문자열로 인증 오류와 일반 API 오류를 구분한다.
-        is_auth_error = any(
-            keyword in str(e)
-            for keyword in ("API_KEY", "PERMISSION_DENIED", "UNAUTHENTICATED")
-        )
+        is_auth_error = any(keyword in str(e) for keyword in _AUTH_ERROR_KEYWORDS)
 
         if is_auth_error:
             raise HTTPException(
@@ -99,28 +112,16 @@ async def get_weather_briefing(request: WeatherBriefingRequest) -> WeatherBriefi
             },
         )
 
-    # ── 3단계: 응답 파싱 ──────────────────────────────────────────────────────────
+    # 3. 응답 파싱
+    # 파싱의 구체적인 구현은 parser/weather.py에 위임한다.
+    # service는 "파싱이 어떻게 되는지"는 모르고,
+    # "파싱이 실패했을 때 어떤 HTTP 응답을 줄지"만 책임진다.
     try:
-        # response.text: Gemini가 반환한 원시 문자열
-        # response_mime_type="application/json" 덕분에 순수 JSON 문자열
-        raw_text = response.text
+        return parse_briefing_response(response.text)
 
-        # JSON 문자열 → Python dict로 변환
-        data = json.loads(raw_text)
-
-        # dict → Pydantic 모델로 변환
-        # IconCode(data["icon_code"]): 문자열 "CLOUDY" → IconCode.CLOUDY Enum 변환
-        # [Clothing(c) for c in data["clothing"]]: 문자열 리스트 → Clothing Enum 리스트 변환
-        return WeatherBriefingResponse(
-            message=data["message"],
-            icon_code=IconCode(data["icon_code"]),
-            clothing=[Clothing(c) for c in data["clothing"]],
-        )
-
-    except (json.JSONDecodeError, KeyError, ValueError) as e:
-        # json.JSONDecodeError: Gemini가 JSON이 아닌 형식으로 응답한 경우
-        # KeyError: JSON에 필수 키(message, icon_code, clothing)가 없는 경우
-        # ValueError: Enum 변환 실패 — 정의되지 않은 icon_code/clothing 값을 반환한 경우
+    except (ValueError, KeyError) as e:
+        # ValueError  : icon_code 또는 clothing이 정의된 Enum 범위를 벗어난 경우
+        # KeyError    : JSON에 필수 키(message, icon_code, clothing)가 없는 경우
         raise HTTPException(
             status_code=502,
             detail={
@@ -128,3 +129,16 @@ async def get_weather_briefing(request: WeatherBriefingRequest) -> WeatherBriefi
                 "message": f"Gemini 응답 파싱에 실패했습니다: {str(e)}",
             },
         )
+
+    except Exception as e:
+        # json.JSONDecodeError 포함, 예상치 못한 파싱 오류 전체를 처리한다.
+        # json.JSONDecodeError는 ValueError의 하위 클래스이지만,
+        # 명시적으로 분리해 "JSON 자체가 깨진 경우"임을 로그/메시지에서 구분할 수 있도록 한다.
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "error_code": ErrorCode.GEMINI_PARSE_ERROR,
+                "message": f"Gemini 응답이 유효한 JSON 형식이 아닙니다: {str(e)}",
+            },
+        )
+

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,8 +1,13 @@
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 from fastapi.testclient import TestClient
 from fastapi import HTTPException
 
 # SDK import 차단
+# 이유:
+#   google.generativeai는 import 시점에 네트워크/인증을 시도할 수 있다.
+#   테스트 환경에서는 실제 SDK가 불필요하므로, sys.modules에 MagicMock을 주입해
+#   import 자체를 가로챈다.
 import sys
 sys.modules["google.generativeai"] = MagicMock()
 sys.modules["google.ai.generativelanguage_v1beta"] = MagicMock()
@@ -13,7 +18,11 @@ from app.schema.error import ErrorCode  # noqa: E402
 
 client = TestClient(app)
 
+# ── 공통 픽스처 ───────────────────────────────────────────────────────────────
+
 # 공통 요청 바디
+# 모든 테스트에서 동일한 요청 바디를 사용한다.
+# 하드코딩 방지를 위해 모듈 레벨 상수로 정의한다.
 VALID_REQUEST_BODY = {
     "member_id": 1,
     "cold_sensitivity": "NORMAL",
@@ -28,13 +37,60 @@ VALID_REQUEST_BODY = {
     },
 }
 
-# patch 대상 경로
+# patch 대상 경로 상수
 # 이유:
 #   patch는 "실제로 사용되는 위치"를 기준으로 해야 한다.
 #   router/weather.py가 get_weather_briefing을 import해서 호출하므로
 #   app.router.weather 네임스페이스의 참조를 patch해야 mock이 적용된다.
 #   app.service.weather를 patch하면 이미 router가 가진 참조에는 영향을 주지 않는다.
-PATCH_TARGET = "app.router.weather.get_weather_briefing"
+_ROUTER_PATCH_TARGET = "app.router.weather.get_weather_briefing"
+
+# parse_briefing_response patch 대상 경로
+# 이유:
+#   parse_briefing_response는 app.service.weather에서 import해서 사용한다.
+#   따라서 app.service.weather 네임스페이스의 참조를 patch해야 mock이 적용된다.
+_PARSER_PATCH_TARGET = "app.service.weather.parse_briefing_response"
+
+# Gemini model.generate_content_async patch 대상 경로
+# 이유:
+#   parse_briefing_response가 호출되려면 Gemini 호출이 먼저 성공해야 한다.
+#   실제 Gemini API를 호출하지 않도록 GenerativeModel 생성자를 mock으로 대체한다.
+_GEMINI_MODEL_PATCH_TARGET = "app.service.weather.genai.GenerativeModel"
+
+# Gemini mock 응답 텍스트
+# parse_briefing_response가 호출될 때 전달받을 raw_text 값이다.
+# 실제 파싱은 _PARSER_PATCH_TARGET으로 mock되므로, 이 값의 내용은 중요하지 않다.
+# 단, response.text 접근이 가능해야 하므로 유효한 JSON 문자열을 사용한다.
+_MOCK_GEMINI_RAW_RESPONSE = json.dumps({
+    "message": "mock 메시지입니다.",
+    "icon_code": "SUNNY",
+    "clothing": ["T_SHIRT"],
+})
+
+
+def _make_mock_gemini_model(raw_text: str) -> MagicMock:
+    """
+    Gemini GenerativeModel을 대체하는 mock 객체를 생성합니다.
+
+    Args:
+        raw_text (str): generate_content_async()가 반환할 mock response의 text 값.
+
+    Returns:
+        MagicMock: GenerativeModel mock 객체.
+                   generate_content_async()는 response.text = raw_text인 AsyncMock을 반환한다.
+    """
+    # response.text 속성을 가진 mock response 객체
+    mock_response = MagicMock()
+    mock_response.text = raw_text
+
+    # generate_content_async()는 코루틴이므로 AsyncMock을 사용한다.
+    mock_model = MagicMock()
+    mock_model.generate_content_async = AsyncMock(return_value=mock_response)
+
+    return mock_model
+
+
+# ── 기존 테스트: HTTPException 핸들러 포맷 검증 ───────────────────────────────
 
 # 핸들러 포맷 검증
 # 검증 목표:
@@ -50,7 +106,7 @@ class TestHttpExceptionHandler:
         - error_code 값이 문자열 "GEMINI_AUTH_ERROR"인지 확인 (Enum 직렬화 검증)
         """
         with patch(
-            PATCH_TARGET,
+            _ROUTER_PATCH_TARGET,
             new_callable=AsyncMock,
             side_effect=HTTPException(
                 status_code=401,
@@ -74,7 +130,7 @@ class TestHttpExceptionHandler:
         GEMINI_API_ERROR 발생 시 HTTP 502 + ErrorResponse 포맷 확인
         """
         with patch(
-            PATCH_TARGET,
+            _ROUTER_PATCH_TARGET,
             new_callable=AsyncMock,
             side_effect=HTTPException(
                 status_code=502,
@@ -96,7 +152,7 @@ class TestHttpExceptionHandler:
         GEMINI_TIMEOUT 발생 시 HTTP 504 + ErrorResponse 포맷 확인
         """
         with patch(
-            PATCH_TARGET,
+            _ROUTER_PATCH_TARGET,
             new_callable=AsyncMock,
             side_effect=HTTPException(
                 status_code=504,
@@ -119,7 +175,7 @@ class TestHttpExceptionHandler:
         INTERNAL_SERVER_ERROR로 폴백되는지 확인
         """
         with patch(
-            PATCH_TARGET,
+            _ROUTER_PATCH_TARGET,
             new_callable=AsyncMock,
             side_effect=HTTPException(
                 status_code=500,
@@ -131,3 +187,84 @@ class TestHttpExceptionHandler:
         assert response.status_code == 500
         body = response.json()
         assert body["error_code"] == "INTERNAL_SERVER_ERROR"
+
+
+# ── 신규 테스트: GEMINI_PARSE_ERROR 시나리오 검증 ────────────────────────────
+
+# 검증 목표:
+#   parser(parse_briefing_response)가 예외를 던졌을 때,
+#   service(get_weather_briefing)가 이를 올바른 GEMINI_PARSE_ERROR HTTPException으로
+#   변환하는지 확인한다.
+#
+# Mock 전략:
+#   - _GEMINI_MODEL_PATCH_TARGET: Gemini API 호출을 mock해 실제 네트워크 요청을 차단한다.
+#     parse_briefing_response가 호출되려면 Gemini 호출이 먼저 성공해야 하기 때문이다.
+#   - _PARSER_PATCH_TARGET: parse_briefing_response를 mock해 파싱 실패 상황을 격리 재현한다.
+#     Gemini 응답 내용과 무관하게 파싱 예외만 테스트할 수 있다.
+class TestGeminiParseError:
+
+    def test_json_decode_error_returns_502(self):
+        """
+        parse_briefing_response가 json.JSONDecodeError를 발생시킬 때
+        - HTTP 502 반환
+        - error_code가 "GEMINI_PARSE_ERROR"인지 확인
+        - message에 파싱 실패 관련 문구가 포함됐는지 확인
+
+        시나리오: Gemini가 JSON이 아닌 텍스트를 반환한 경우
+        """
+        mock_model = _make_mock_gemini_model(_MOCK_GEMINI_RAW_RESPONSE)
+
+        with patch(_GEMINI_MODEL_PATCH_TARGET, return_value=mock_model), \
+             patch(
+                 _PARSER_PATCH_TARGET,
+                 side_effect=json.JSONDecodeError("mock decode error", doc="", pos=0),
+             ):
+            response = client.post("/api/v1/weather/briefing", json=VALID_REQUEST_BODY)
+
+        assert response.status_code == 502
+        body = response.json()
+        assert body["error_code"] == "GEMINI_PARSE_ERROR"
+        assert "GEMINI_PARSE_ERROR" == body["error_code"]  # JSONDecodeError는 ValueError 하위 클래스로 파싱 실패 블록에서 처리됨
+
+    def test_key_error_returns_502(self):
+        """
+        parse_briefing_response가 KeyError를 발생시킬 때
+        - HTTP 502 반환
+        - error_code가 "GEMINI_PARSE_ERROR"인지 확인
+
+        시나리오: JSON에 필수 키(message, icon_code, clothing 중 하나)가 없는 경우
+        """
+        mock_model = _make_mock_gemini_model(_MOCK_GEMINI_RAW_RESPONSE)
+
+        with patch(_GEMINI_MODEL_PATCH_TARGET, return_value=mock_model), \
+             patch(
+                 _PARSER_PATCH_TARGET,
+                 side_effect=KeyError("icon_code"),
+             ):
+            response = client.post("/api/v1/weather/briefing", json=VALID_REQUEST_BODY)
+
+        assert response.status_code == 502
+        body = response.json()
+        assert body["error_code"] == "GEMINI_PARSE_ERROR"
+
+    def test_value_error_returns_502(self):
+        """
+        parse_briefing_response가 ValueError를 발생시킬 때
+        - HTTP 502 반환
+        - error_code가 "GEMINI_PARSE_ERROR"인지 확인
+
+        시나리오: icon_code 또는 clothing 값이 정의된 Enum 범위를 벗어난 경우
+                  예) icon_code: "HAIL" — IconCode에 정의되지 않은 값
+        """
+        mock_model = _make_mock_gemini_model(_MOCK_GEMINI_RAW_RESPONSE)
+
+        with patch(_GEMINI_MODEL_PATCH_TARGET, return_value=mock_model), \
+             patch(
+                 _PARSER_PATCH_TARGET,
+                 side_effect=ValueError("'HAIL' is not a valid IconCode"),
+             ):
+            response = client.post("/api/v1/weather/briefing", json=VALID_REQUEST_BODY)
+
+        assert response.status_code == 502
+        body = response.json()
+        assert body["error_code"] == "GEMINI_PARSE_ERROR"


### PR DESCRIPTION
## 📣 Related Issue

- #14

## 📝 Summary

- `app/parser/weather.py` 신규 생성 — Gemini raw JSON 문자열을 WeatherBriefingResponse로 변환하는 파싱 전담 레이어 분리
- `app/service/weather.py` 리팩토링 — 인라인 파싱 로직을 `parse_briefing_response()` 호출로 교체, 하드코딩 문자열 상수 추출
- `tests/test_main.py` — `TestGeminiParseError` 클래스 추가 (json.JSONDecodeError / KeyError / ValueError 3가지 시나리오)

## 🙏 PR point

- `parser/` 를 별도 레이어로 분리한 이유: 현재는 날씨 브리핑 하나지만, 이후 기능 확장 시 `parser/todo.py`, `parser/archive.py` 등이 자연스럽게 추가될 수 있도록 확장성을 고려했습니다.
- `parse_briefing_response()`는 FastAPI / HTTPException에 완전히 독립적인 순수 변환 함수입니다. 파싱 예외는 service 레이어에서 HTTPException으로 변환합니다.
- 테스트는 실제 Gemini API 키 없이 실행 가능합니다. SDK import와 API 호출을 모두 mock으로 차단했습니다.

**테스트 실행 방법**
```bash
# 전체 실행
pytest tests/test_main.py -v

# 이번 이슈 추가분만
pytest tests/test_main.py::TestGeminiParseError -v
```

## 📬 Reference

- `app/schema/weather.py`
- `docs/api-contract.md`