### PR TITLE
[🔧Chore/#18] Docker 환경 구성

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# 가상환경 — 컨테이너 안에서 pip install로 새로 구성하므로 제외
+.venv/
+
+# 환경변수 — 컨테이너 실행 시 docker-compose.yml의 env_file로 주입
+.env
+
+# Python 캐시
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# 테스트 코드 — 프로덕션 이미지에 불필요
+tests/
+
+# IDE
+.idea/
+.vscode/
+
+# Git
+.git/
+.gitignore
+
+# 문서
+docs/
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Python 3.11 slim 이미지를 베이스로 사용
+# slim: 불필요한 OS 패키지를 제거한 경량 이미지 (보안 + 용량 최적화)
+FROM python:3.11-slim
+
+# 컨테이너 내 작업 디렉토리 설정
+WORKDIR /app
+
+# 의존성 파일만 먼저 복사 후 설치
+# 이유: requirements.txt가 변경되지 않으면 이 레이어는 캐시를 재사용한다.
+#       소스 코드가 바뀌어도 의존성 재설치를 생략해 빌드 속도를 높인다.
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# 소스 코드 복사 (.dockerignore에서 제외된 파일은 복사되지 않음)
+COPY . .
+
+# FastAPI 서버가 사용하는 포트 명시 (문서화 목적, 실제 포트 바인딩은 docker-compose에서 담당)
+EXPOSE 8000
+
+# 컨테이너 실행 시 uvicorn 서버 시작
+# --host 0.0.0.0: 컨테이너 외부에서 접근 가능하도록 모든 인터페이스에 바인딩
+# --port 8000: 명시적 포트 지정
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -55,3 +55,30 @@ GET http://localhost:8000/health
 ### 7. API 문서
 http://localhost:8000/docs
 
+---
+
+## Docker 실행 가이드
+
+### 1. 환경변수 설정
+
+로컬 개발 가이드의 4번과 동일하게 `.env` 파일을 준비해주세요.
+
+```bash
+cp .env.example .env
+# .env 파일을 열어 GEMINI_API_KEY 값을 채워주세요.
+```
+
+### 2. 컨테이너 빌드 및 실행
+
+```bash
+docker-compose up --build
+```
+
+### 3. 헬스체크
+GET http://localhost:8000/health
+
+### 4. 컨테이너 종료
+
+```bash
+docker-compose down
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  dayleaf-ai:
+    build: .
+    container_name: dayleaf-ai
+    ports:
+      - "8000:8000"
+    env_file:
+      # .env 파일의 GEMINI_API_KEY를 컨테이너 환경변수로 주입
+      # .env 파일은 .dockerignore로 이미지에 포함되지 않으며,
+      # 런타임에만 주입되므로 키가 이미지에 노출되지 않는다.
+      - .env
+    # 컨테이너 비정상 종료 시 자동 재시작
+    restart: unless-stopped


### PR DESCRIPTION
## 📣 Related Issue

- #18

## 📝 Summary

- `Dockerfile` 작성 (Python 3.11-slim 베이스 이미지, uvicorn 실행)
- `.dockerignore` 작성 (`.venv`, `.env`, `__pycache__`, `tests/` 등 제외)
- `docker-compose.yml` 작성 (로컬 개발용, `.env`를 통한 환경변수 주입)
- `README.md` Docker 실행 가이드 섹션 추가

## 🙏PR point

- `.env` 파일은 `.dockerignore`로 이미지에 포함되지 않으며, `docker-compose.yml`의 `env_file`을 통해 런타임에만 주입됩니다. `GEMINI_API_KEY`가 이미지에 노출되지 않습니다.
- 로컬 실행 시 `docker-compose up --build` 한 줄로 서버를 띄울 수 있습니다.

## 📬 Reference