### PR TITLE
[🔧Chore/#22] google-genai SDK 마이그레이션

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         # 단, app/core/gemini.py의 환경변수 검증을 우회하기 위해 더미 값을 주입한다.
         env:
           GEMINI_API_KEY: "dummy-key-for-ci"
-        run: pytest
+        run: python -m pytest
 
   docker-build:
     name: Docker 이미지 빌드 검증

--- a/app/core/gemini.py
+++ b/app/core/gemini.py
@@ -1,9 +1,8 @@
-# Gemini API 키를 로드하고 genai 클라이언트를 초기화한다.
+# Gemini API 키를 로드하고 google-genai 클라이언트를 초기화한다.
 # 이 모듈의 책임은 인증 설정까지이다.
 
 import os
-
-import google.generativeai as genai
+from google import genai
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -13,4 +12,6 @@ GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
 if not GEMINI_API_KEY:
     raise ValueError("GEMINI_API_KEY가 설정되지 않았습니다. .env 파일을 확인해주세요.")
 
-genai.configure(api_key=GEMINI_API_KEY)
+# 새 SDK는 genai.configure() 대신 Client 객체로 인증한다.
+# 이 client 인스턴스를 service 레이어에서 import해서 사용한다.
+client = genai.Client(api_key=GEMINI_API_KEY)

--- a/app/service/weather.py
+++ b/app/service/weather.py
@@ -7,13 +7,12 @@
 # - service/weather.py: Gemini 호출 + 예외의 HTTP 변환 책임
 # - parser/weather.py : raw JSON 문자열 → Pydantic 모델 변환 (순수 변환, HTTP 무관)
 
-import google.generativeai as genai
-from fastapi import HTTPException
+from google.genai import types
 from google.api_core.exceptions import DeadlineExceeded, GoogleAPICallError
+from fastapi import HTTPException
 
-# core/gemini.py의 import만으로 genai.configure()가 실행된다.
-# 즉, 이 줄 하나로 Gemini API 키 인증이 완료된다.
-import app.core.gemini
+# core/gemini.py import로 Client 인스턴스를 가져온다.
+from app.core.gemini import client
 
 from app.parser.weather import parse_briefing_response
 from app.prompt.weather import SYSTEM_PROMPT, build_user_prompt
@@ -21,25 +20,15 @@ from app.schema.error import ErrorCode
 from app.schema.weather import WeatherBriefingRequest, WeatherBriefingResponse
 
 # Gemini 모델 이름 상수
-# 하드코딩된 문자열 대신 상수로 관리한다.
-# 이유:
-#   - 모델 이름 변경 시 이 상수만 수정하면 된다.
-#   - 오타로 인한 런타임 오류를 방지한다.
 _GEMINI_MODEL_NAME = "models/gemini-2.5-flash"
 
-# Gemini GenerationConfig 상수
-# 각 값의 의미와 선택 이유를 상수명과 주석으로 명시한다.
-
-# temperature: 모델의 창의성 수준 (0.0 ~ 1.0)
-# 0.7 = 분류 정확성(icon_code, clothing)과 문체 다양성(message)의 균형점
+# temperature: 분류 정확성과 문체 다양성의 균형점
 _TEMPERATURE = 0.7
 
 # max_output_tokens: 브리핑 메시지(2문장) + JSON 구조 오버헤드를 고려한 적정 토큰 수
 _MAX_OUTPUT_TOKENS = 2048
 
 # 인증 에러 판별 키워드 목록
-# GoogleAPICallError 메시지 문자열로 인증 오류와 일반 API 오류를 구분한다.
-# 하드코딩 방지를 위해 상수로 분리하며, 새로운 키워드 추가 시 이 목록만 수정한다.
 _AUTH_ERROR_KEYWORDS = ("API_KEY", "PERMISSION_DENIED", "UNAUTHENTICATED")
 
 
@@ -47,32 +36,22 @@ async def get_weather_briefing(request: WeatherBriefingRequest) -> WeatherBriefi
     """
     날씨 브리핑 생성의 진입점(entry point).
 
-    이 함수는 라우터에서 직접 호출되며, 크게 세 단계로 동작한다:
-      1단계) 유저 프롬프트 빌드: cold_sensitivity와 날씨 데이터를 자연어로 조합
-      2단계) Gemini API 호출: 시스템 프롬프트 + 유저 프롬프트로 JSON 브리핑 생성
-      3단계) 응답 파싱: raw JSON 문자열을 parser 레이어에 위임 후 HTTPException으로 변환
+    1단계) 유저 프롬프트 빌드
+    2단계) Gemini API 호출
+    3단계) 응답 파싱
     """
 
     # 1. 유저 프롬프트 빌드
-    # build_user_prompt()는 app/prompt/weather.py에서 정의된 함수.
-    # cold_sensitivity Enum을 자연어로 변환하고,
-    # 날씨 데이터를 마크다운 형식으로 조립해 Gemini가 읽기 쉬운 텍스트를 만든다.
     user_prompt = build_user_prompt(request)
 
     # 2. Gemini API 호출
     try:
-        # system_instruction은 generate_content_async()가 아닌
-        # GenerativeModel() 생성자에 전달해야 한다.
-        model = genai.GenerativeModel(
-            model_name=_GEMINI_MODEL_NAME,
-            system_instruction=SYSTEM_PROMPT,  # 사서 '리프'의 페르소나 및 응답 규칙
-        )
-
-        response = await model.generate_content_async(
-            # 유저 메시지: 이번 요청의 날씨 데이터 + 체질 정보
+        response = await client.aio.models.generate_content(
+            model=_GEMINI_MODEL_NAME,
             contents=[user_prompt],
-
-            generation_config=genai.GenerationConfig(
+            config=types.GenerateContentConfig(
+                # 사서 '리프'의 페르소나 및 응답 규칙
+                system_instruction=SYSTEM_PROMPT,
                 # JSON만 반환하도록 모델 레벨에서 강제한다.
                 response_mime_type="application/json",
                 temperature=_TEMPERATURE,
@@ -81,7 +60,6 @@ async def get_weather_briefing(request: WeatherBriefingRequest) -> WeatherBriefi
         )
 
     except DeadlineExceeded:
-        # Gemini API 응답이 SDK 기본 타임아웃을 초과한 경우
         raise HTTPException(
             status_code=504,
             detail={
@@ -91,8 +69,6 @@ async def get_weather_briefing(request: WeatherBriefingRequest) -> WeatherBriefi
         )
 
     except GoogleAPICallError as e:
-        # GoogleAPICallError는 Gemini SDK의 모든 API 오류의 상위 예외.
-        # 에러 메시지 문자열로 인증 오류와 일반 API 오류를 구분한다.
         is_auth_error = any(keyword in str(e) for keyword in _AUTH_ERROR_KEYWORDS)
 
         if is_auth_error:
@@ -113,15 +89,10 @@ async def get_weather_briefing(request: WeatherBriefingRequest) -> WeatherBriefi
         )
 
     # 3. 응답 파싱
-    # 파싱의 구체적인 구현은 parser/weather.py에 위임한다.
-    # service는 "파싱이 어떻게 되는지"는 모르고,
-    # "파싱이 실패했을 때 어떤 HTTP 응답을 줄지"만 책임진다.
     try:
         return parse_briefing_response(response.text)
 
     except (ValueError, KeyError) as e:
-        # ValueError  : icon_code 또는 clothing이 정의된 Enum 범위를 벗어난 경우
-        # KeyError    : JSON에 필수 키(message, icon_code, clothing)가 없는 경우
         raise HTTPException(
             status_code=502,
             detail={
@@ -131,9 +102,6 @@ async def get_weather_briefing(request: WeatherBriefingRequest) -> WeatherBriefi
         )
 
     except Exception as e:
-        # json.JSONDecodeError 포함, 예상치 못한 파싱 오류 전체를 처리한다.
-        # json.JSONDecodeError는 ValueError의 하위 클래스이지만,
-        # 명시적으로 분리해 "JSON 자체가 깨진 경우"임을 로그/메시지에서 구분할 수 있도록 한다.
         raise HTTPException(
             status_code=502,
             detail={
@@ -141,4 +109,3 @@ async def get_weather_briefing(request: WeatherBriefingRequest) -> WeatherBriefi
                 "message": f"Gemini 응답이 유효한 JSON 형식이 아닙니다: {str(e)}",
             },
         )
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ google-api-core==2.30.3
 google-api-python-client==2.194.0
 google-auth==2.49.2
 google-auth-httplib2==0.3.1
-google-generativeai==0.8.6
+google-genai==1.17.0
 googleapis-common-protos==1.74.0
 grpcio==1.80.0
 grpcio-status==1.71.2
@@ -40,4 +40,4 @@ urllib3==2.6.3
 uvicorn==0.45.0
 uvloop==0.22.1
 watchfiles==1.1.1
-websockets==16.0
+websockets==14.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,4 @@ uvicorn==0.45.0
 uvloop==0.22.1
 watchfiles==1.1.1
 websockets==14.2
+pytest==9.0.3

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,14 +3,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from fastapi.testclient import TestClient
 from fastapi import HTTPException
 
-# SDK import 차단
+# SDK import 차단 (google-genai 기준)
 # 이유:
-#   google.generativeai는 import 시점에 네트워크/인증을 시도할 수 있다.
+#   google.genai는 import 시점에 네트워크/인증을 시도할 수 있다.
 #   테스트 환경에서는 실제 SDK가 불필요하므로, sys.modules에 MagicMock을 주입해
 #   import 자체를 가로챈다.
 import sys
-sys.modules["google.generativeai"] = MagicMock()
-sys.modules["google.ai.generativelanguage_v1beta"] = MagicMock()
+sys.modules["google.genai"] = MagicMock()
+sys.modules["google.genai.types"] = MagicMock()
 sys.modules["app.core.gemini"] = MagicMock()
 
 from main import app  # noqa: E402 (SDK mock 이후에 import해야 하므로 순서 고정)
@@ -51,11 +51,12 @@ _ROUTER_PATCH_TARGET = "app.router.weather.get_weather_briefing"
 #   따라서 app.service.weather 네임스페이스의 참조를 patch해야 mock이 적용된다.
 _PARSER_PATCH_TARGET = "app.service.weather.parse_briefing_response"
 
-# Gemini model.generate_content_async patch 대상 경로
+# Gemini generate_content patch 대상 경로
 # 이유:
-#   parse_briefing_response가 호출되려면 Gemini 호출이 먼저 성공해야 한다.
-#   실제 Gemini API를 호출하지 않도록 GenerativeModel 생성자를 mock으로 대체한다.
-_GEMINI_MODEL_PATCH_TARGET = "app.service.weather.genai.GenerativeModel"
+#   새 SDK는 GenerativeModel 대신 client.aio.models.generate_content를 직접 호출한다.
+#   parse_briefing_response가 호출되려면 Gemini 호출이 먼저 성공해야 하므로
+#   이 경로를 mock해 실제 네트워크 요청을 차단한다.
+_GEMINI_MODEL_PATCH_TARGET = "app.service.weather.client.aio.models.generate_content"
 
 # Gemini mock 응답 텍스트
 # parse_briefing_response가 호출될 때 전달받을 raw_text 값이다.
@@ -68,26 +69,19 @@ _MOCK_GEMINI_RAW_RESPONSE = json.dumps({
 })
 
 
-def _make_mock_gemini_model(raw_text: str) -> MagicMock:
+def _make_mock_gemini_response(raw_text: str) -> MagicMock:
     """
-    Gemini GenerativeModel을 대체하는 mock 객체를 생성합니다.
+    client.aio.models.generate_content()가 반환할 mock response 객체를 생성합니다.
 
     Args:
-        raw_text (str): generate_content_async()가 반환할 mock response의 text 값.
+        raw_text (str): response.text에 담길 mock 값.
 
     Returns:
-        MagicMock: GenerativeModel mock 객체.
-                   generate_content_async()는 response.text = raw_text인 AsyncMock을 반환한다.
+        MagicMock: response.text = raw_text인 mock 객체.
     """
-    # response.text 속성을 가진 mock response 객체
     mock_response = MagicMock()
     mock_response.text = raw_text
-
-    # generate_content_async()는 코루틴이므로 AsyncMock을 사용한다.
-    mock_model = MagicMock()
-    mock_model.generate_content_async = AsyncMock(return_value=mock_response)
-
-    return mock_model
+    return mock_response
 
 
 # ── 기존 테스트: HTTPException 핸들러 포맷 검증 ───────────────────────────────
@@ -208,23 +202,22 @@ class TestGeminiParseError:
         parse_briefing_response가 json.JSONDecodeError를 발생시킬 때
         - HTTP 502 반환
         - error_code가 "GEMINI_PARSE_ERROR"인지 확인
-        - message에 파싱 실패 관련 문구가 포함됐는지 확인
 
         시나리오: Gemini가 JSON이 아닌 텍스트를 반환한 경우
         """
-        mock_model = _make_mock_gemini_model(_MOCK_GEMINI_RAW_RESPONSE)
-
-        with patch(_GEMINI_MODEL_PATCH_TARGET, return_value=mock_model), \
-             patch(
-                 _PARSER_PATCH_TARGET,
-                 side_effect=json.JSONDecodeError("mock decode error", doc="", pos=0),
-             ):
+        with patch(
+            _GEMINI_MODEL_PATCH_TARGET,
+            new_callable=AsyncMock,
+            return_value=_make_mock_gemini_response(_MOCK_GEMINI_RAW_RESPONSE),
+        ), patch(
+            _PARSER_PATCH_TARGET,
+            side_effect=json.JSONDecodeError("mock decode error", doc="", pos=0),
+        ):
             response = client.post("/api/v1/weather/briefing", json=VALID_REQUEST_BODY)
 
         assert response.status_code == 502
         body = response.json()
         assert body["error_code"] == "GEMINI_PARSE_ERROR"
-        assert "GEMINI_PARSE_ERROR" == body["error_code"]  # JSONDecodeError는 ValueError 하위 클래스로 파싱 실패 블록에서 처리됨
 
     def test_key_error_returns_502(self):
         """
@@ -234,13 +227,14 @@ class TestGeminiParseError:
 
         시나리오: JSON에 필수 키(message, icon_code, clothing 중 하나)가 없는 경우
         """
-        mock_model = _make_mock_gemini_model(_MOCK_GEMINI_RAW_RESPONSE)
-
-        with patch(_GEMINI_MODEL_PATCH_TARGET, return_value=mock_model), \
-             patch(
-                 _PARSER_PATCH_TARGET,
-                 side_effect=KeyError("icon_code"),
-             ):
+        with patch(
+            _GEMINI_MODEL_PATCH_TARGET,
+            new_callable=AsyncMock,
+            return_value=_make_mock_gemini_response(_MOCK_GEMINI_RAW_RESPONSE),
+        ), patch(
+            _PARSER_PATCH_TARGET,
+            side_effect=KeyError("icon_code"),
+        ):
             response = client.post("/api/v1/weather/briefing", json=VALID_REQUEST_BODY)
 
         assert response.status_code == 502
@@ -256,13 +250,14 @@ class TestGeminiParseError:
         시나리오: icon_code 또는 clothing 값이 정의된 Enum 범위를 벗어난 경우
                   예) icon_code: "HAIL" — IconCode에 정의되지 않은 값
         """
-        mock_model = _make_mock_gemini_model(_MOCK_GEMINI_RAW_RESPONSE)
-
-        with patch(_GEMINI_MODEL_PATCH_TARGET, return_value=mock_model), \
-             patch(
-                 _PARSER_PATCH_TARGET,
-                 side_effect=ValueError("'HAIL' is not a valid IconCode"),
-             ):
+        with patch(
+            _GEMINI_MODEL_PATCH_TARGET,
+            new_callable=AsyncMock,
+            return_value=_make_mock_gemini_response(_MOCK_GEMINI_RAW_RESPONSE),
+        ), patch(
+            _PARSER_PATCH_TARGET,
+            side_effect=ValueError("'HAIL' is not a valid IconCode"),
+        ):
             response = client.post("/api/v1/weather/briefing", json=VALID_REQUEST_BODY)
 
         assert response.status_code == 502


### PR DESCRIPTION
## 📣 Related Issue

- #22

## 📝 Summary

- `app/core/gemini.py` — `genai.configure()` 방식에서 `genai.Client()` 기반으로 변경
- `app/service/weather.py` — `GenerativeModel().generate_content_async()` 방식에서 `client.aio.models.generate_content()`로 변경, `system_instruction`을 `GenerateContentConfig` 안으로 이동
- `requirements.txt` — `google-generativeai==0.8.6` 제거, `google-genai==1.17.0` 추가, `websockets` 의존성 충돌로 `16.0` → `14.2` 다운그레이드
- `tests/test_main.py` — `sys.modules` mock 대상을 `google.genai` 기준으로 변경, `_make_mock_gemini_model` → `_make_mock_gemini_response`로 교체, 전체 테스트 `new_callable=AsyncMock` 패턴으로 통일

## 🙏 PR point

- `websockets` 버전을 `16.0` → `14.2`로 다운그레이드했습니다. `google-genai==1.17.0`이 `websockets<15.1.0`을 요구하기 때문입니다. 기존 기능에는 영향 없습니다.
- `system_instruction`이 `GenerativeModel` 생성자에서 `GenerateContentConfig` 안으로 이동했습니다. 새 SDK에서는 모델 객체가 없어지고 단일 호출로 통합되기 때문입니다.

## 📬 Reference

- [google-genai 공식 문서](https://googleapis.github.io/python-genai/)
- [마이그레이션 가이드](https://ai.google.dev/gemini-api/docs/migrate)